### PR TITLE
feat: Error Handling to mark jobs with job_id "cancelled" or "timed out" as failed in the airflow interface

### DIFF
--- a/src/sas_airflow_provider/operators/sas_studioflow.py
+++ b/src/sas_airflow_provider/operators/sas_studioflow.py
@@ -119,13 +119,22 @@ class SASStudioFlowOperator(BaseOperator):
         if self.flow_exec_log is True:
             _dump_logs(session, job)
 
-        # raise exception in Airflow if SAS Studio Flow ended execution with "failed" state
+        # raise exception in Airflow if SAS Studio Flow ended execution with "failed" "canceled" or "timed out" state
         if job_state == "failed":
             raise AirflowFailException(
                 "SAS Studio Flow Execution completed with an error. See log for details "
                 "(set flow_exec_log to True in the operator to turn on logging)"
             )
-
+        if job_state == "canceled":
+            raise AirflowFailException(
+                "SAS Studio Flow Execution was canceled or aborted. See log for details "
+                "(set flow_exec_log to True in the operator to turn on logging)"
+            )
+        if job_state == "timed out":
+            raise AirflowFailException(
+                "SAS Studio Flow Execution has timed out. See log for details "
+                "(set flow_exec_log to True in the operator to turn on logging)"
+            )
         return 1
 
 


### PR DESCRIPTION
Fixes #5 

 add a new airflow exception when job_state == "canceled" and job_state == "timed out" so that the operator marks such tasks as failed instead of successful.


Signed-off-by: Charalampos Kamvysis [haralampos@kamvysis.com](mailto:haralampos@kamvysis.com)