### PR TITLE
Updated status code check in jobexecution

### DIFF
--- a/src/sas_airflow_provider/operators/sas_jobexecution.py
+++ b/src/sas_airflow_provider/operators/sas_jobexecution.py
@@ -71,7 +71,7 @@ class SASJobExecutionOperator(BaseOperator):
         headers = {"Accept": "application/vnd.sas.job.execution.job+json"}
         response = session.post(url, headers=headers, data=payload, verify=False)
 
-        if response.status_code != 200:
+        if(response.status_code < 200 or response.status_code > 300):
             raise AirflowFailException(f"SAS Job Execution HTTP status code {response.status_code}")
 
         return 1


### PR DESCRIPTION
JobExecutionOperator currently checks for an HTTP status code of 200. This should be expanded to all successful status codes (200-299).