### PR TITLE
Added allways_reuse_session in SASStudioOperator to configure a task to reuse a compute session or run in parallel 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sas-airflow-provider
-version = 0.0.10
+version = 0.0.11
 author = SAS
 author_email = andrew.shakinovsky@sas.com
 description = Enables execution of Studio Flows and Jobs from Airflow


### PR DESCRIPTION
Enables SASStudioOperator tasks to always reuse the same Compute Session across all tasks when setting allways_reuse_session=True. Default value is False meaning a new unnamed compute sessions will always be created to enable SASStudioOperator tasks run in parallel. In addition, management of compute sessions have been improved. If needed, compute sessions are now terminated after a SASStudioOperator task have completed.