### PR TITLE
Added optional parameter http_timeout to avoid the risk of HTTP-call's running indefinitely

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sas-airflow-provider
-version = 0.0.12
+version = 0.0.13
 author = SAS
 author_email = andrew.shakinovsky@sas.com
 description = Enables execution of Studio Flows and Jobs from Airflow


### PR DESCRIPTION
To avoid the risk of HTTP-call's running indefinitely, optional parameter http_timeout can now be specified when creating a task. Default timeout is set to (30.05, 300) and is applied to all HTTP-calls. Upgraded to version 0.0.13