### PR TITLE
Update sas_studio.py - add on_failure_callback function

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sas-airflow-provider
-version = 0.0.13
+version = 0.0.14
 author = SAS
 author_email = andrew.shakinovsky@sas.com
 description = Enables execution of Studio Flows and Jobs from Airflow

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -146,7 +146,12 @@ class SASStudioOperator(BaseOperator):
 
         # Use hooks to clean up
         self.on_success_callback=[on_success]
-        self.on_failure_callback=[on_failure]
+        
+        if self.on_failure_callback == None:
+           self.on_failure_callback=[on_failure]
+        else:
+            self.on_failure_callback=[on_failure, self.on_failure_callback]
+        
         self.on_retry_callback=[on_retry]
 
         # Timeout


### PR DESCRIPTION
Adding the possibility to use own functions in parameter "on_failure_callback". 
We need to have a chance to alert clients (by creating Jira tickets) once the task fails. Till now the parameter "on_failure_callback" was occupied by clean_up function and airflow allowed only one function to be passed. Now that airflow updated this and allows an array of functions to be passed. We are using this to pass our function to create Jira Tickets. 
