### PR TITLE
Add timedOut as state to sas operators. 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sas-airflow-provider
-version = 0.0.13
+version = 0.0.14
 author = SAS
 author_email = andrew.shakinovsky@sas.com
 description = Enables execution of Studio Flows and Jobs from Airflow

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -146,7 +146,12 @@ class SASStudioOperator(BaseOperator):
 
         # Use hooks to clean up
         self.on_success_callback=[on_success]
-        self.on_failure_callback=[on_failure]
+        
+        if self.on_failure_callback == None:
+           self.on_failure_callback=[on_failure]
+        else:
+            self.on_failure_callback=[on_failure, self.on_failure_callback]
+        
         self.on_retry_callback=[on_retry]
 
         # Timeout

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -381,7 +381,7 @@ class SASStudioOperator(BaseOperator):
 
         self.log.info("Job request has completed execution with the status: " + str(state))
         success = True
-        if state in ['failed', 'canceled', 'timed out']:
+        if state in ['failed', 'canceled', 'timed out', 'timedOut']:
             success = False
             if 'error' in job:
                 self.log.error(job['error'])

--- a/src/sas_airflow_provider/operators/sas_studioflow.py
+++ b/src/sas_airflow_provider/operators/sas_studioflow.py
@@ -143,6 +143,9 @@ class SASStudioFlowOperator(BaseOperator):
         if job_state == "timed out":
             raise AirflowException("SAS Studio Flow Execution has timed out. See log for details ")
 
+        if job_state == "timedOut":
+            raise AirflowException("SAS Studio Flow Execution has timed out. See log for details ")
+
         return 1
 
 


### PR DESCRIPTION
As Viya started to return "timedOut" as job state instead of "timed out", we need to add this as a possible option. Has been added to 2 .py scripts where we found this could happen. Since we have a client waiting for this with a blocker, we would like to sort this pretty quickly. 

Regards
Dario Koltunowicz
SAS 