### PR TITLE
Makes sure to forward any Airflow Exception's during state checking, else they are ignored and that we do not want.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sas-airflow-provider
-version = 0.0.18
+version = 0.0.19
 author = SAS
 author_email = andrew.shakinovsky@sas.com
 description = Enables execution of Studio Flows and Jobs from Airflow

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -380,7 +380,7 @@ class SASStudioOperator(BaseOperator):
                         num_log_lines=stream_log(self.connection, job, num_log_lines, http_timeout=self.http_timeout)
                             
             except Exception as e:
-                # Makes sure to forward any AirflowException's encountered during state checking, else continue checking.
+                # We makes sure to forward any AirflowException's encountered during state checking, else continue checking.
                 if isinstance(e,AirflowTaskTimeout) or isinstance(e,AirflowException):
                     raise
                 else:

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -224,7 +224,7 @@ class SASStudioOperator(BaseOperator):
         # Kick off the JES job, wait to get the state
         # _run_job_and_wait will poll for new 
         # SAS log-lines and stream them in the DAG'-log
-        job, success = self._run_job_and_wait(jr, 0.5)
+        job, success = self._run_job_and_wait(jr, 10)
         job_state= "unknown"
         if "state" in job:
             job_state = job["state"]


### PR DESCRIPTION
A problem was encountered at a site where configuring a DAG to use execution_timeout was simply ignored. The root cause was determined to be that AirflowTaskTimeout exceptions was simply being ignored during state checking. This code change will fix this. Please note that the code introduced checks for AirflowTaskTimeout as well as AirflowException instances. This is by design, as the documentation/code is not clear about inheritance of AirflowTaskTimeout (could be derived from BaseException as well as from AirflowException).