### PR TITLE
Changing fg_uicolor to hex value to comply with mask required by airflow

### DIFF
--- a/src/sas_airflow_provider/operators/sas_create_session.py
+++ b/src/sas_airflow_provider/operators/sas_create_session.py
@@ -43,7 +43,7 @@ class SASComputeCreateSession(BaseOperator):
     """
 
     ui_color = "#CCE5FF"
-    ui_fgcolor = "black"
+    ui_fgcolor = "#000000"
 
     # template fields are fields which can be templated out in the Airflow task using {{ }}
     template_fields: Sequence[str] = ("compute_context_name", "session_name")

--- a/src/sas_airflow_provider/operators/sas_delete_session.py
+++ b/src/sas_airflow_provider/operators/sas_delete_session.py
@@ -36,7 +36,7 @@ class SASComputeDeleteSession(BaseOperator):
     """
 
     ui_color = "#CCE5FF"
-    ui_fgcolor = "black"
+    ui_fgcolor = "#000000"
 
     # template fields are fields which can be templated out in the Airflow task using {{ }}
     template_fields: Sequence[str] = ("compute_session_id", "compute_session_name")

--- a/src/sas_airflow_provider/operators/sas_studio.py
+++ b/src/sas_airflow_provider/operators/sas_studio.py
@@ -99,7 +99,7 @@ class SASStudioOperator(BaseOperator):
     """
 
     ui_color = "#CCE5FF"
-    ui_fgcolor = "black"
+    ui_fgcolor = "#000000"
 
 
     

--- a/src/sas_airflow_provider/operators/sas_studioflow.py
+++ b/src/sas_airflow_provider/operators/sas_studioflow.py
@@ -51,7 +51,7 @@ class SASStudioFlowOperator(BaseOperator):
     """
 
     ui_color = "#CCE5FF"
-    ui_fgcolor = "black"
+    ui_fgcolor = "#000000"
 
     template_fields: Sequence[str] = ("env_vars",)
 


### PR DESCRIPTION
For newer Airflow version fg_uicolor has a requirement to match hex mask. Value 'black' results in errors in web UI (also in REST api). Example of error below. I tested change on latest Airflow version as well as older one (2.7) and everything is working correctly.

![2025-02-05_15h11_24](https://github.com/user-attachments/assets/a62cd1dd-c53b-48b1-ae42-90773632a3f1)

Signed-off-by: Paweł Szymczak [pawel.szymczak@sas.com](mailto:pawel.szymczak@sas.com)